### PR TITLE
Move tink-cc http_archive to deps.bzl and add public filegroups

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+bazel-*
+.DS_Store

--- a/Tink/BUILD.bazel
+++ b/Tink/BUILD.bazel
@@ -83,9 +83,23 @@ PUBLIC_API_DEPS = [
     "//Tink/util:strings",
 ]
 
+filegroup(
+    name = "public_headers",
+    srcs = PUBLIC_APIS,
+    visibility = ["//visibility:public"],
+)
+
+filegroup(
+    name = "cleartext_headers",
+    srcs = [
+        "TINKKeysetHandle+Cleartext.h",
+    ],
+    visibility = ["//visibility:public"],
+)
+
 objc_library(
     name = "objc",
-    hdrs = PUBLIC_APIS,
+    hdrs = [":public_headers"],
     visibility = ["//visibility:public"],
     deps = PUBLIC_API_DEPS,
 )
@@ -93,7 +107,8 @@ objc_library(
 objc_library(
     name = "testonly",
     testonly = 1,
-    hdrs = PUBLIC_APIS + [
+    hdrs = [
+        ":public_headers",
         "TINKKeysetHandle+Cleartext.h",
     ],
     visibility = ["//visibility:public"],
@@ -104,7 +119,8 @@ objc_library(
 
 ios_static_framework(
     name = "Tink_framework",
-    hdrs = PUBLIC_APIS + [
+    hdrs = [
+        ":public_headers",
         "TINKKeysetHandle+Cleartext.h",
     ],
     bundle_name = "Tink",
@@ -112,6 +128,20 @@ ios_static_framework(
     deps = [
         ":cleartext_keyset_handle",
         ":objc",
+    ],
+)
+
+objc_library(
+    name = "cleartext_keyset_handle",
+    srcs = ["core/TINKKeysetHandle+Cleartext.mm"],
+    hdrs = [":cleartext_headers"],
+    visibility = ["//visibility:public"],
+    deps = [
+        "//Tink:keyset_handle",
+        "//Tink:keyset_reader",
+        "//Tink/proto_redirect:tink_cc_pb_redirect",
+        "//Tink/util:errors",
+        "@tink_cc//tink:cleartext_keyset_handle",
     ],
 )
 
@@ -148,21 +178,6 @@ objc_library(
         "@com_google_absl//absl/status",
         "@com_google_absl//absl/strings",
         "@tink_cc//tink:binary_keyset_reader",
-    ],
-)
-
-objc_library(
-    name = "cleartext_keyset_handle",
-    srcs = ["core/TINKKeysetHandle+Cleartext.mm"],
-    hdrs = [
-        "TINKKeysetHandle+Cleartext.h",
-    ],
-    deps = [
-        "//Tink:keyset_handle",
-        "//Tink:keyset_reader",
-        "//Tink/proto_redirect:tink_cc_pb_redirect",
-        "//Tink/util:errors",
-        "@tink_cc//tink:cleartext_keyset_handle",
     ],
 )
 

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -1,12 +1,12 @@
 workspace(name = "tink_objc")
 
-load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
+load("@tink_objc//:tink_objc_deps.bzl", "tink_objc_deps")
 
-http_archive(
-    name = "tink_cc",
-    urls = ["https://github.com/tink-crypto/tink-cc/archive/main.zip"],
-    strip_prefix = "tink-cc-main",
-)
+tink_objc_deps()
+
+load("@tink_objc//:tink_objc_deps_init.bzl", "tink_objc_deps_init")
+
+tink_objc_deps_init()
 
 load("@tink_cc//:tink_cc_deps.bzl", "tink_cc_deps")
 
@@ -15,11 +15,3 @@ tink_cc_deps()
 load("@tink_cc//:tink_cc_deps_init.bzl", "tink_cc_deps_init")
 
 tink_cc_deps_init()
-
-load("@tink_objc//:tink_objc_deps.bzl", "tink_objc_deps")
-
-tink_objc_deps()
-
-load("@tink_objc//:tink_objc_deps_init.bzl", "tink_objc_deps_init")
-
-tink_objc_deps_init()

--- a/tink_objc_deps.bzl
+++ b/tink_objc_deps.bzl
@@ -4,6 +4,13 @@ load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 
 def tink_objc_deps():
     """Dependencies for Tink Objective C."""
+    if not native.existing_rule("tink_cc"):
+        # Main
+        http_archive(
+            name = "tink_cc",
+            urls = ["https://github.com/tink-crypto/tink-cc/archive/main.zip"],
+            strip_prefix = "tink-cc-main",
+        )
     if not native.existing_rule("build_bazel_rules_apple"):
         # Release from 2022-12-21.
         http_archive(


### PR DESCRIPTION
Changes:

- Moves the download of `tink-cc` to `deps.bzl` so consumers don't need to add this to their WORKSPACE file.
  - Should this have a `sha256` by the way? Right now it's unversioned since it points to `main`.
- Add `filegroup` for the `PUBLIC_API` headers
- Add `filegroup` for the ClearText header (or should this be moved to `PUBLIC_API`, our project seems to depend on this API and its not declared public here)
- Make `cleartext` public so it can be used by consumers

 